### PR TITLE
Made kind of BENode public

### DIFF
--- a/bencode.nim
+++ b/bencode.nim
@@ -26,7 +26,7 @@ type
     tkDict
 
   BENode* = object
-    case kind: BENodeKind
+    case kind*: BENodeKind
     of tkInt: intVal*: int
     of tkBytes: strVal*: string
     of tkList: listVal*: seq[BENode]

--- a/bencode.nimble
+++ b/bencode.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Federico Ceratto"
 description   = "bencode library"
 license       = "LGPLv3"


### PR DESCRIPTION
Now users can differentiate nodes by kind.
Without this I keep getting an error:
```
Error: type mismatch: got <BENode>
but expected one of:
proc kind(n: NimNode): NimNodeKind
  first type mismatch at position: 1
  required type for n: NimNode
  but expression 'result' is of type: BENode
```